### PR TITLE
feat: export `Document` and `DocumentVersion` types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
 export { reader } from './reader.js'
 export { write } from './writer.js'
+/** @typedef {import('./types.js').Document} Document */
+/** @typedef {import('./types.js').DocumentVersion} DocumentVersion */

--- a/src/reader.js
+++ b/src/reader.js
@@ -2,18 +2,11 @@ import { buffer } from 'node:stream/consumers'
 import * as v from 'valibot'
 import yauzl from 'yauzl-promise'
 import { DocumentVersionSchema } from './types.js'
-/** @import { DocumentVersion } from './types.js' */
+/** @import { Document, DocumentVersion } from './types.js' */
 
 /**
  * @internal
  * @typedef {Map<string, yauzl.Entry>} EntriesByFilename
- */
-
-/**
- * @internal
- * @typedef {object} Document
- * @prop {string} id
- * @prop {Array<DocumentVersion>} versions
  */
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -27,3 +27,9 @@ export const DocumentVersionSchema = v.object({
     blockIndex: v.number(),
   }),
 })
+
+/**
+ * @typedef {object} Document
+ * @prop {string} id
+ * @prop {Array<DocumentVersion>} versions
+ */


### PR DESCRIPTION
These will be useful for our importer, so I think they're worth exporting.

I plan to YOLO-merge this if CI passes.